### PR TITLE
Mpi sn solver

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,9 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 find_package( OpenMP REQUIRED )
 
+find_package( MPI REQUIRED )
+include_directories( ${MPI_INCLUDE_PATH} )
+
 find_package( LAPACK REQUIRED )
 include_directories( ${LAPACK_INCLUDE_DIR} )
 
@@ -55,7 +58,7 @@ include_directories( ${CMAKE_SOURCE_DIR}/ext/blaze )
 include_directories( ${CMAKE_SOURCE_DIR}/ext/cpptoml/include )
 include_directories( ${CMAKE_SOURCE_DIR}/ext/spdlog/include )
 
-set( CORE_LIBRARIES ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}  ${VTK_LIBRARIES} OpenMP::OpenMP_CXX -lstdc++fs )
+set( CORE_LIBRARIES ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_LIBRARIES} ${VTK_LIBRARIES} OpenMP::OpenMP_CXX -lstdc++fs )
 
 
 #################################################

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option( BUILD_DOC "builds Doxygen and Sphinx documentation" OFF )
 option( BUILD_UNITY "enables unity build for faster compile times" ON )
 option( BUILD_CODE_COV "enables compiler option required for code coverage analysis" OFF )
 option( BUILD_ML "enables build with tensorflow backend access" OFF )
+option( BUILD_MPI "enables build with MPI access" OFF )
 
 #################################################
 
@@ -31,8 +32,10 @@ set(CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake ${CMAKE_MODULE_PATH})
 
 find_package( OpenMP REQUIRED )
 
-find_package( MPI REQUIRED )
-include_directories( ${MPI_INCLUDE_PATH} )
+if( BUILD_MPI )
+    find_package( MPI REQUIRED )
+    include_directories( ${MPI_INCLUDE_PATH} )
+endif()
 
 find_package( LAPACK REQUIRED )
 include_directories( ${LAPACK_INCLUDE_DIR} )
@@ -58,7 +61,11 @@ include_directories( ${CMAKE_SOURCE_DIR}/ext/blaze )
 include_directories( ${CMAKE_SOURCE_DIR}/ext/cpptoml/include )
 include_directories( ${CMAKE_SOURCE_DIR}/ext/spdlog/include )
 
-set( CORE_LIBRARIES ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_LIBRARIES} ${VTK_LIBRARIES} OpenMP::OpenMP_CXX -lstdc++fs )
+if( BUILD_MPI )
+    set( CORE_LIBRARIES ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES} ${MPI_LIBRARIES} ${VTK_LIBRARIES} OpenMP::OpenMP_CXX -lstdc++fs )
+else()
+    set( CORE_LIBRARIES ${LAPACK_LIBRARIES} ${BLAS_LIBRARIES}  ${VTK_LIBRARIES} OpenMP::OpenMP_CXX -lstdc++fs )
+endif()
 
 
 #################################################

--- a/include/common/mesh.hpp
+++ b/include/common/mesh.hpp
@@ -129,6 +129,10 @@ class Mesh
      *  @return cell_idx: unsigned */
     unsigned GetCellOfKoordinate( const double x, const double y ) const;
 
+      /*! @brief Returns index of cells contained in the ball around the coordinate (x,y) with radius r
+     *  @return cell_idxs:   std::vector<unsigned> */
+    std::vector<unsigned> GetCellsofBall( const double x, const double y, const double r ) const;
+
     /*! @brief ComputeSlopes calculates the slope in every cell into x and y direction using the divergence theorem.
      *  @param nq is number of quadrature points
      *  @param psiDerX is slope in x direction (gets computed. Slope is stored here)

--- a/include/solvers/snsolver_hpc.hpp
+++ b/include/solvers/snsolver_hpc.hpp
@@ -111,7 +111,7 @@ class SNSolverHPC
     double _curAbsorptionHohlraumVertical;
     double _curAbsorptionHohlraumHorizontal;
     double _varAbsorptionHohlraumGreen;
-    std::vector<unsigned> _probingCellsHohlraum; /*!< @brief Indices of cells that contain a probing sensor */
+    std::vector<  std::vector<unsigned>> _probingCellsHohlraum; /*!< @brief Indices of cells that contain a probing sensor */
     std::vector<double> _probingMoments;         /*!< @brief Solution Momnets at the probing cells that contain a probing sensor */
     unsigned _probingMomentsTimeIntervals;       /*!< @brief Solution Momnets at the probing cells that contain a probing sensor */
 

--- a/include/solvers/snsolver_hpc.hpp
+++ b/include/solvers/snsolver_hpc.hpp
@@ -18,6 +18,12 @@ class SNSolverHPC
 {
 
   private:
+    int _rank;
+    int _numProcs;
+    unsigned _localNSys;
+    unsigned _startSysIdx;
+    unsigned _endSysIdx;
+
     double _currTime;  /*!< @brief wall-time after current iteration */
     Config* _settings; /*!< @brief config class for global information */
     Mesh* _mesh;
@@ -146,10 +152,6 @@ class SNSolverHPC
     void FVMUpdate();
 
     void IterPostprocessing();
-
-    /*! @brief Computes the finite Volume update step for the current iteration
-         @param idx_iter  current (peudo) time iteration */
-    void RKUpdate( std::vector<double>& sol0, std::vector<double>& sol_rk );
 
     void SetGhostCells(); /*!< @brief Sets vector of ghost cells for
 

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -5,6 +5,7 @@
  *
  * Disclaimer: This class structure was copied and modifed with open source permission from SU2 v7.0.3 https://su2code.github.io/
  */
+#include <mpi.h>
 
 #include "common/config.hpp"
 #include "common/globalconstants.hpp"
@@ -1202,159 +1203,165 @@ bool Config::TokenizeString( string& str, string& option_name, vector<string>& o
 }
 
 void Config::InitLogger() {
+    int rank;
+    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
 
-    // Declare Logger
-    spdlog::level::level_enum terminalLogLvl;
-    spdlog::level::level_enum fileLogLvl;
+    if( rank == 0 ) {
 
-    // Choose Logger
+        // Declare Logger
+        spdlog::level::level_enum terminalLogLvl;
+        spdlog::level::level_enum fileLogLvl;
+
+        // Choose Logger
 #ifdef BUILD_TESTING
-    terminalLogLvl = spdlog::level::err;
-    fileLogLvl     = spdlog::level::info;
+        terminalLogLvl = spdlog::level::err;
+        fileLogLvl     = spdlog::level::info;
 #elif NDEBUG
-    terminalLogLvl = spdlog::level::info;
-    fileLogLvl     = spdlog::level::info;
+        terminalLogLvl = spdlog::level::info;
+        fileLogLvl     = spdlog::level::info;
 #else
-    terminalLogLvl = spdlog::level::debug;
-    fileLogLvl     = spdlog::level::debug;
+        terminalLogLvl = spdlog::level::debug;
+        fileLogLvl     = spdlog::level::debug;
 #endif
 
-    // create log dir if not existent
-    if( !std::filesystem::exists( _logDir ) ) {
-        std::filesystem::create_directory( _logDir );
-    }
-
-    if( !spdlog::get( "event" ) ) {
-        // create sinks if level is not off
-        std::vector<spdlog::sink_ptr> sinks;
-        if( terminalLogLvl != spdlog::level::off ) {
-            // create spdlog terminal sink
-            auto terminalSink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
-            terminalSink->set_level( terminalLogLvl );
-            terminalSink->set_pattern( "%v" );
-            sinks.push_back( terminalSink );
+        // create log dir if not existent
+        if( !std::filesystem::exists( _logDir ) ) {
+            std::filesystem::create_directory( _logDir );
         }
-        if( fileLogLvl != spdlog::level::off ) {
-            // define filename on root
-            // int pe = 0;
-            // MPI_Comm_rank( MPI_COMM_WORLD, &pe );
-            // char cfilename[1024];
 
-            // if( pe == 0 ) {
-            //  get date and time
-            time_t now = time( nullptr );
-            struct tm tstruct;
-            char buf[80];
-            tstruct = *localtime( &now );
-            strftime( buf, sizeof( buf ), "%Y-%m-%d_%X", &tstruct );
-
-            // set filename
-            std::string filepathStr;
-            if( _logFileName.compare( "use_date" ) == 0 ) {
-                _logFileName = buf;    // set filename to date and time
-                filepathStr  = _logDir + _logFileName;
+        if( !spdlog::get( "event" ) ) {
+            // create sinks if level is not off
+            std::vector<spdlog::sink_ptr> sinks;
+            if( terminalLogLvl != spdlog::level::off ) {
+                // create spdlog terminal sink
+                auto terminalSink = std::make_shared<spdlog::sinks::stdout_sink_mt>();
+                terminalSink->set_level( terminalLogLvl );
+                terminalSink->set_pattern( "%v" );
+                sinks.push_back( terminalSink );
             }
-            else {
-                std::filesystem::path filePath( _logDir + _logFileName );
-                std::string baseFilename( _logDir + _logFileName );
-                filepathStr = _logDir + _logFileName;
-                // Check if the file with the original name exists
-                if( std::filesystem::exists( filePath ) ) {
-                    // Extract the stem and extension
-                    std::string stem      = filePath.stem().string();
-                    std::string extension = filePath.extension().string();
+            if( fileLogLvl != spdlog::level::off ) {
+                // define filename on root
+                // int pe = 0;
+                // MPI_Comm_rank( MPI_COMM_WORLD, &pe );
+                // char cfilename[1024];
 
-                    // Counter for incrementing the filename
-                    int counter = 1;
+                // if( pe == 0 ) {
+                //  get date and time
+                time_t now = time( nullptr );
+                struct tm tstruct;
+                char buf[80];
+                tstruct = *localtime( &now );
+                strftime( buf, sizeof( buf ), "%Y-%m-%d_%X", &tstruct );
 
-                    // Keep incrementing the counter until a unique filename is found
-                    while( std::filesystem::exists( filePath ) ) {
-                        stem = baseFilename + std::to_string( counter );
-                        filePath.replace_filename( stem + extension );
-                        counter++;
-                    }
+                // set filename
+                std::string filepathStr;
+                if( _logFileName.compare( "use_date" ) == 0 ) {
+                    _logFileName = buf;    // set filename to date and time
+                    filepathStr  = _logDir + _logFileName;
                 }
-                filepathStr = filePath.string();
-            }
-            //}
-            // MPI_Bcast( &cfilename, sizeof( cfilename ), MPI_CHAR, 0, MPI_COMM_WORLD );
-            // MPI_Barrier( MPI_COMM_WORLD );
+                else {
+                    std::filesystem::path filePath( _logDir + _logFileName );
+                    std::string baseFilename( _logDir + _logFileName );
+                    filepathStr = _logDir + _logFileName;
+                    // Check if the file with the original name exists
+                    if( std::filesystem::exists( filePath ) ) {
+                        // Extract the stem and extension
+                        std::string stem      = filePath.stem().string();
+                        std::string extension = filePath.extension().string();
 
-            // create spdlog file sink
-            auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>( filepathStr );
-            fileSink->set_level( fileLogLvl );
-            fileSink->set_pattern( "%Y-%m-%d %H:%M:%S.%f | %v" );
-            sinks.push_back( fileSink );
-        }
+                        // Counter for incrementing the filename
+                        int counter = 1;
 
-        // register all sinks
-        auto event_logger = std::make_shared<spdlog::logger>( "event", begin( sinks ), end( sinks ) );
-        spdlog::register_logger( event_logger );
-        spdlog::flush_every( std::chrono::seconds( 5 ) );
-    }
-
-    if( !spdlog::get( "tabular" ) ) {
-        // create sinks if level is not off
-        std::vector<spdlog::sink_ptr> sinks;
-        if( fileLogLvl != spdlog::level::off ) {
-            // define filename on root
-            // int pe = 0;
-            // MPI_Comm_rank( MPI_COMM_WORLD, &pe );
-            // char cfilename[1024];
-
-            // if( pe == 0 ) {
-            //  get date and time
-            time_t now = time( nullptr );
-            struct tm tstruct;
-            char buf[80];
-            tstruct = *localtime( &now );
-            strftime( buf, sizeof( buf ), "%Y-%m-%d_%X.csv", &tstruct );
-
-            // set filename
-            // set filename
-            std::string filepathStr;
-            if( _logFileName.compare( "use_date" ) == 0 ) {
-                _logFileName = buf;    // set filename to date and time
-                filepathStr  = _logDir + _logFileName + ".csv";
-            }
-            else {
-                std::filesystem::path filePath( _logDir + _logFileName + ".csv" );
-                std::string baseFilename( _logDir + _logFileName );
-                filepathStr = _logDir + _logFileName + ".csv";
-                // Check if the file with the original name exists
-                if( std::filesystem::exists( filePath ) ) {
-                    // Extract the stem and extension
-                    std::string stem      = filePath.stem().string();
-                    std::string extension = filePath.extension().string();
-
-                    // Counter for incrementing the filename
-                    int counter = 1;
-
-                    // Keep incrementing the counter until a unique filename is found
-                    while( std::filesystem::exists( filePath ) ) {
-                        stem = baseFilename + std::to_string( counter );
-                        filePath.replace_filename( stem + extension );
-                        counter++;
+                        // Keep incrementing the counter until a unique filename is found
+                        while( std::filesystem::exists( filePath ) ) {
+                            stem = baseFilename + std::to_string( counter );
+                            filePath.replace_filename( stem + extension );
+                            counter++;
+                        }
                     }
+                    filepathStr = filePath.string();
                 }
-                filepathStr = filePath.string();
-            }
-            //}
-            // MPI_Bcast( &cfilename, sizeof( cfilename ), MPI_CHAR, 0, MPI_COMM_WORLD );
-            // MPI_Barrier( MPI_COMM_WORLD );
+                //}
+                // MPI_Bcast( &cfilename, sizeof( cfilename ), MPI_CHAR, 0, MPI_COMM_WORLD );
+                // MPI_Barrier( MPI_COMM_WORLD );
 
-            // create spdlog file sink
-            auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>( filepathStr );
-            fileSink->set_level( fileLogLvl );
-            fileSink->set_pattern( "%Y-%m-%d %H:%M:%S.%f ,%v" );
-            sinks.push_back( fileSink );
+                // create spdlog file sink
+                auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>( filepathStr );
+                fileSink->set_level( fileLogLvl );
+                fileSink->set_pattern( "%Y-%m-%d %H:%M:%S.%f | %v" );
+                sinks.push_back( fileSink );
+            }
+
+            // register all sinks
+            auto event_logger = std::make_shared<spdlog::logger>( "event", begin( sinks ), end( sinks ) );
+            spdlog::register_logger( event_logger );
+            spdlog::flush_every( std::chrono::seconds( 5 ) );
         }
 
-        // register all sinks
-        auto tabular_logger = std::make_shared<spdlog::logger>( "tabular", begin( sinks ), end( sinks ) );
-        spdlog::register_logger( tabular_logger );
-        spdlog::flush_every( std::chrono::seconds( 5 ) );
+        if( !spdlog::get( "tabular" ) ) {
+            // create sinks if level is not off
+            std::vector<spdlog::sink_ptr> sinks;
+            if( fileLogLvl != spdlog::level::off ) {
+                // define filename on root
+                // int pe = 0;
+                // MPI_Comm_rank( MPI_COMM_WORLD, &pe );
+                // char cfilename[1024];
+
+                // if( pe == 0 ) {
+                //  get date and time
+                time_t now = time( nullptr );
+                struct tm tstruct;
+                char buf[80];
+                tstruct = *localtime( &now );
+                strftime( buf, sizeof( buf ), "%Y-%m-%d_%X.csv", &tstruct );
+
+                // set filename
+                // set filename
+                std::string filepathStr;
+                if( _logFileName.compare( "use_date" ) == 0 ) {
+                    _logFileName = buf;    // set filename to date and time
+                    filepathStr  = _logDir + _logFileName + ".csv";
+                }
+                else {
+                    std::filesystem::path filePath( _logDir + _logFileName + ".csv" );
+                    std::string baseFilename( _logDir + _logFileName );
+                    filepathStr = _logDir + _logFileName + ".csv";
+                    // Check if the file with the original name exists
+                    if( std::filesystem::exists( filePath ) ) {
+                        // Extract the stem and extension
+                        std::string stem      = filePath.stem().string();
+                        std::string extension = filePath.extension().string();
+
+                        // Counter for incrementing the filename
+                        int counter = 1;
+
+                        // Keep incrementing the counter until a unique filename is found
+                        while( std::filesystem::exists( filePath ) ) {
+                            stem = baseFilename + std::to_string( counter );
+                            filePath.replace_filename( stem + extension );
+                            counter++;
+                        }
+                    }
+                    filepathStr = filePath.string();
+                }
+                //}
+                // MPI_Bcast( &cfilename, sizeof( cfilename ), MPI_CHAR, 0, MPI_COMM_WORLD );
+                // MPI_Barrier( MPI_COMM_WORLD );
+
+                // create spdlog file sink
+                auto fileSink = std::make_shared<spdlog::sinks::basic_file_sink_mt>( filepathStr );
+                fileSink->set_level( fileLogLvl );
+                fileSink->set_pattern( "%Y-%m-%d %H:%M:%S.%f ,%v" );
+                sinks.push_back( fileSink );
+            }
+
+            // register all sinks
+            auto tabular_logger = std::make_shared<spdlog::logger>( "tabular", begin( sinks ), end( sinks ) );
+            spdlog::register_logger( tabular_logger );
+            spdlog::flush_every( std::chrono::seconds( 5 ) );
+        }
     }
+    MPI_Barrier( MPI_COMM_WORLD );
 }
 
 // Function to find the key for a given value in a map

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -795,6 +795,7 @@ void Config::SetPostprocessing() {
                                      TOTAL_PARTICLE_ABSORPTION_CENTER,
                                      TOTAL_PARTICLE_ABSORPTION_VERTICAL,
                                      TOTAL_PARTICLE_ABSORPTION_HORIZONTAL,
+                                     TOTAL_PARTICLE_ABSORPTION,
                                      PROBE_MOMENT_TIME_TRACE,
                                      VAR_ABSORPTION_GREEN };
 
@@ -941,6 +942,7 @@ void Config::SetPostprocessing() {
                                      TOTAL_PARTICLE_ABSORPTION_CENTER,
                                      TOTAL_PARTICLE_ABSORPTION_VERTICAL,
                                      TOTAL_PARTICLE_ABSORPTION_HORIZONTAL,
+                                     TOTAL_PARTICLE_ABSORPTION,
                                      PROBE_MOMENT_TIME_TRACE,
                                      VAR_ABSORPTION_GREEN,
                                      VAR_ABSORPTION_GREEN_LINE };

--- a/src/common/config.cpp
+++ b/src/common/config.cpp
@@ -5,8 +5,9 @@
  *
  * Disclaimer: This class structure was copied and modifed with open source permission from SU2 v7.0.3 https://su2code.github.io/
  */
+#ifdef BUILD_MPI
 #include <mpi.h>
-
+#endif
 #include "common/config.hpp"
 #include "common/globalconstants.hpp"
 #include "common/optionstructure.hpp"
@@ -1205,8 +1206,10 @@ bool Config::TokenizeString( string& str, string& option_name, vector<string>& o
 }
 
 void Config::InitLogger() {
-    int rank;
-    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+    int rank = 0;
+#ifdef BUILD_MPI
+    MPI_Comm_rank( MPI_COMM_WORLD, &rank );    // Initialize MPI
+#endif
 
     if( rank == 0 ) {
 
@@ -1363,7 +1366,9 @@ void Config::InitLogger() {
             spdlog::flush_every( std::chrono::seconds( 5 ) );
         }
     }
+#ifdef BUILD_MPI
     MPI_Barrier( MPI_COMM_WORLD );
+#endif
 }
 
 // Function to find the key for a given value in a map

--- a/src/common/io.cpp
+++ b/src/common/io.cpp
@@ -14,10 +14,10 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+#include <mpi.h>
+#include <omp.h>
 #include <sstream>
 #include <vector>
-// #include <mpi.h>
-#include <omp.h>
 #include <vtkCellArray.h>
 #include <vtkCellData.h>
 #include <vtkCellDataToPointData.h>
@@ -141,7 +141,7 @@ void ExportVTK( const std::string fileName,
 
 Mesh* LoadSU2MeshFromFile( const Config* settings ) {
     auto log = spdlog::get( "event" );
-    log->info( "| Importing mesh. This may take a while for large meshes." );
+    // log->info( "| Importing mesh. This may take a while for large meshes." );
     unsigned dim;
     std::vector<Vector> nodes;
     std::vector<std::vector<unsigned>> cells;
@@ -300,7 +300,7 @@ Mesh* LoadSU2MeshFromFile( const Config* settings ) {
         ErrorMessages::Error( "Cannot open mesh file '" + settings->GetMeshFile() + "!", CURRENT_FUNCTION );
     }
     ifs.close();
-    log->info( "| Mesh imported." );
+    // log->info( "| Mesh imported." );
     return new Mesh( settings, nodes, cells, boundaries );
 }
 
@@ -461,8 +461,8 @@ std::string ParseArguments( int argc, char* argv[] ) {
 void PrintLogHeader( std::string inputFile ) {
     int nprocs = 1;
     int rank   = 0;
-    // MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
-    // MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+    MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
+    MPI_Comm_rank( MPI_COMM_WORLD, &rank );
     if( rank == 0 ) {
         auto log = spdlog::get( "event" );
 
@@ -498,7 +498,7 @@ void PrintLogHeader( std::string inputFile ) {
         }
         // log->info( "------------------------------------------------------------------------" );
     }
-    // MPI_Barrier( MPI_COMM_WORLD );
+    MPI_Barrier( MPI_COMM_WORLD );
 }
 
 /*

--- a/src/common/io.cpp
+++ b/src/common/io.cpp
@@ -14,7 +14,11 @@
 #include <fstream>
 #include <iomanip>
 #include <iostream>
+
+#ifdef BUILD_MPI
 #include <mpi.h>
+#endif
+
 #include <omp.h>
 #include <sstream>
 #include <vector>
@@ -461,8 +465,11 @@ std::string ParseArguments( int argc, char* argv[] ) {
 void PrintLogHeader( std::string inputFile ) {
     int nprocs = 1;
     int rank   = 0;
+#ifdef BUILD_MPI
+    // Initialize MPI
     MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
     MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+#endif
     if( rank == 0 ) {
         auto log = spdlog::get( "event" );
 
@@ -498,7 +505,9 @@ void PrintLogHeader( std::string inputFile ) {
         }
         // log->info( "------------------------------------------------------------------------" );
     }
+#ifdef BUILD_MPI
     MPI_Barrier( MPI_COMM_WORLD );
+#endif
 }
 
 /*

--- a/src/common/mesh.cpp
+++ b/src/common/mesh.cpp
@@ -6,7 +6,9 @@
 #include <filesystem>
 #include <iostream>
 #include <map>
+#ifdef BUILD_MPI
 #include <mpi.h>
+#endif
 #include <omp.h>
 #include <set>
 
@@ -26,8 +28,10 @@ Mesh::Mesh( const Config* settings,
     }
     int nprocs = 1;
     int rank   = 0;
+#ifdef BUILD_MPI
     MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
     MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+#endif
     if( rank == 0 ) {
 
         auto log = spdlog::get( "event" );
@@ -91,8 +95,10 @@ Mesh::~Mesh() {}
 void Mesh::ComputeConnectivity() {
     int nprocs = 1;
     int rank   = 0;
+#ifdef BUILD_MPI
     MPI_Comm_size( MPI_COMM_WORLD, &nprocs );
     MPI_Comm_rank( MPI_COMM_WORLD, &rank );
+#endif
 
     unsigned comm_size = 1;    // No MPI implementation right now
     // determine number/chunk size and indices of cells treated by each mpi thread (deactivated for now)
@@ -615,6 +621,8 @@ std::vector<unsigned> Mesh::GetCellsofBall( const double x, const double y, cons
     }
 
     if( cells_in_ball.empty() ) {    // take the only cell that contains the point
+        std::cout << "No cells found within the ball centered at (" << x << "," << y << ") with radius " << r << "." << std::endl;
+        std::cout << "Taking the only cell that contains the point." << std::endl;
         cells_in_ball.push_back( GetCellOfKoordinate( x, y ) );
         // ErrorMessages::Error( "No cells found within the ball centered at (" + std::to_string( x ) + "," + std::to_string( y ) + ") with radius " +
         // std::to_string( r ) + ".",

--- a/src/common/mesh.cpp
+++ b/src/common/mesh.cpp
@@ -614,10 +614,11 @@ std::vector<unsigned> Mesh::GetCellsofBall( const double x, const double y, cons
         }
     }
 
-    if( cells_in_ball.empty() ) {
-        ErrorMessages::Error( "No cells found within the ball centered at (" + std::to_string( x ) + "," + std::to_string( y ) + ") with radius " +
-                                  std::to_string( r ) + ".",
-                              CURRENT_FUNCTION );
+    if( cells_in_ball.empty() ) {    // take the only cell that contains the point
+        cells_in_ball.push_back( GetCellOfKoordinate( x, y ) );
+        // ErrorMessages::Error( "No cells found within the ball centered at (" + std::to_string( x ) + "," + std::to_string( y ) + ") with radius " +
+        // std::to_string( r ) + ".",
+        // CURRENT_FUNCTION );
     }
 
     return cells_in_ball;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
  *  @version: 0.1
  */
 
+#include <mpi.h>
 #include <omp.h>
 #include <string>
 
@@ -28,6 +29,7 @@ int main( int argc, char** argv ) {
 #else
     // wchar_t* program = Py_DecodeLocale( argv[0], NULL );
     // Py_SetProgramName( program );
+    MPI_Init( &argc, &argv );
 
     std::string filename = ParseArguments( argc, argv );
 
@@ -61,6 +63,8 @@ int main( int argc, char** argv ) {
     }
 
     delete config;
+
+    MPI_Finalize();
 
     return EXIT_SUCCESS;
 #endif

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,7 +4,9 @@
  *  @version: 0.1
  */
 
+#ifdef BUILD_MPI
 #include <mpi.h>
+#endif
 #include <omp.h>
 #include <string>
 
@@ -27,10 +29,11 @@ int main( int argc, char** argv ) {
     mw.show();
     return app.exec();
 #else
-    // wchar_t* program = Py_DecodeLocale( argv[0], NULL );
-    // Py_SetProgramName( program );
+// wchar_t* program = Py_DecodeLocale( argv[0], NULL );
+// Py_SetProgramName( program );
+#ifdef BUILD_MPI
     MPI_Init( &argc, &argv );
-
+#endif
     std::string filename = ParseArguments( argc, argv );
 
     // CD  Load Settings from File
@@ -63,8 +66,9 @@ int main( int argc, char** argv ) {
     }
 
     delete config;
-
+#ifdef BUILD_MPI
     MPI_Finalize();
+#endif
 
     return EXIT_SUCCESS;
 #endif

--- a/src/problems/halflattice.cpp
+++ b/src/problems/halflattice.cpp
@@ -36,8 +36,8 @@ HalfLattice_SN::HalfLattice_SN( Config* settings, Mesh* mesh, QuadratureBase* qu
     }
     else {
         auto log = spdlog::get( "event" );
-        log->info( "| " );
-        log->info( "| Lattice test case WITHOUT individual scattering and absorption values for each block.  " );
+        //log->info( "| " );
+        //log->info( "| Lattice test case WITHOUT individual scattering and absorption values for each block.  " );
         // For absorption cells: set scattering XS to 0 and absorption to 10
         auto cellMids = _mesh->GetCellMidPoints();
         for( unsigned j = 0; j < cellMids.size(); ++j ) {

--- a/src/problems/hohlraum.cpp
+++ b/src/problems/hohlraum.cpp
@@ -46,7 +46,7 @@ Hohlraum::Hohlraum( Config* settings, Mesh* mesh, QuadratureBase* quad ) : Probl
         }
         // blue area
         if( x > 1.25 || y < 0.05 || y > 1.25 ) {
-            _sigmaS[idx_cell] = 0.0;
+            _sigmaS[idx_cell] = 100.0;
             _sigmaT[idx_cell] = 100.0;
         }
     }

--- a/src/problems/lattice.cpp
+++ b/src/problems/lattice.cpp
@@ -20,9 +20,9 @@ Lattice_SN::Lattice_SN( Config* settings, Mesh* mesh, QuadratureBase* quad ) : P
     _totalAbsorptionLattice  = 0.0;
 
     if( _settings->GetNLatticeAbsIndividual() == 49 && _settings->GetNLatticeScatterIndividual() == 49 ) {    // Individual values set
-        auto log = spdlog::get( "event" );
-        log->info( "| " );
-        log->info( "| Lattice test case WITH individual scattering and absorption values for each block.  " );
+        // auto log = spdlog::get( "event" );
+        // log->info( "| " );
+        // log->info( "| Lattice test case WITH individual scattering and absorption values for each block.  " );
 
         auto cellMids = _mesh->GetCellMidPoints();
 
@@ -35,10 +35,10 @@ Lattice_SN::Lattice_SN( Config* settings, Mesh* mesh, QuadratureBase* quad ) : P
         }
     }
     else {
-        auto log = spdlog::get( "event" );
-        log->info( "| " );
-        log->info( "| Lattice test case WITHOUT individual scattering and absorption values for each block.  " );
-        // For absorption cells: set scattering XS to 0 and absorption to 10
+        // auto log = spdlog::get( "event" );
+        // log->info( "| " );
+        // log->info( "| Lattice test case WITHOUT individual scattering and absorption values for each block.  " );
+        //  For absorption cells: set scattering XS to 0 and absorption to 10
         auto cellMids = _mesh->GetCellMidPoints();
         for( unsigned j = 0; j < cellMids.size(); ++j ) {
             if( IsAbsorption( cellMids[j] ) ) {

--- a/src/problems/quarterhohlraum.cpp
+++ b/src/problems/quarterhohlraum.cpp
@@ -86,7 +86,7 @@ QuarterHohlraum::QuarterHohlraum( Config* settings, Mesh* mesh, QuadratureBase* 
         }
         // black area (upper and lower boundary)
         if( y > 0.6 || y < -0.6 ) {
-            _sigmaS[idx_cell] = 0.0;
+            _sigmaS[idx_cell] = 100.0;
             _sigmaT[idx_cell] = 100.0;
         }
     }

--- a/src/problems/symmetrichohlraum.cpp
+++ b/src/problems/symmetrichohlraum.cpp
@@ -75,27 +75,12 @@ SymmetricHohlraum::SymmetricHohlraum( Config* settings, Mesh* mesh, QuadratureBa
             _sigmaS[idx_cell] = 95.0;
             _sigmaT[idx_cell] = 100.0;
         }
-        // green area 1 (lower boundary)
-        if( x > -0.2 + _centerGreen[0] && x < -0.15 + _centerGreen[0] && y > -0.35 + _centerGreen[1] && y < 0.35 + _centerGreen[1] ) {
+        // green and blue area
+        if( x > -0.2 + _centerGreen[0] && x < 0.2 + _centerGreen[0] && y > -0.4 + _centerGreen[1] && y < 0.4 + _centerGreen[1] ) {
             _sigmaS[idx_cell] = 90.0;
             _sigmaT[idx_cell] = 100.0;
         }
-        // green area 2 (upper boundary)
-        if( x > 0.15 + _centerGreen[0] && x < 0.2 + _centerGreen[0] && y > -0.35 + _centerGreen[1] && y < 0.35 + _centerGreen[1] ) {
-            _sigmaS[idx_cell] = 90.0;
-            _sigmaT[idx_cell] = 100.0;
-        }
-        // green area 3 (left boundary)
-        if( x > -0.2 + _centerGreen[0] && x < 0.2 + _centerGreen[0] && y > -0.4 + _centerGreen[1] && y < -0.35 + _centerGreen[1] ) {
-            _sigmaS[idx_cell] = 90.0;
-            _sigmaT[idx_cell] = 100.0;
-        }
-        // green area 4 (right boundary)
-        if( x > -0.2 + _centerGreen[0] && x < 0.2 + _centerGreen[0] && y > 0.35 + _centerGreen[1] && y < 0.4 + _centerGreen[1] ) {
-            _sigmaS[idx_cell] = 90.0;
-            _sigmaT[idx_cell] = 100.0;
-        }
-        // blue checkered area
+        // blue checkered area (overwrites part of green n blue area)
         if( x > -0.15 + _centerGreen[0] && x < 0.15 + _centerGreen[0] && y > -0.35 + _centerGreen[1] && y < 0.35 + _centerGreen[1] ) {
             _sigmaS[idx_cell] = 50.0;
             _sigmaT[idx_cell] = 100.0;

--- a/src/problems/symmetrichohlraum.cpp
+++ b/src/problems/symmetrichohlraum.cpp
@@ -87,7 +87,7 @@ SymmetricHohlraum::SymmetricHohlraum( Config* settings, Mesh* mesh, QuadratureBa
         }
         // black area (upper and lower boundary)
         if( y > 0.6 || y < -0.6 ) {
-            _sigmaS[idx_cell] = 0.0;
+            _sigmaS[idx_cell] = 100.0;
             _sigmaT[idx_cell] = 100.0;
         }
     }

--- a/src/problems/symmetrichohlraum.cpp
+++ b/src/problems/symmetrichohlraum.cpp
@@ -82,12 +82,12 @@ SymmetricHohlraum::SymmetricHohlraum( Config* settings, Mesh* mesh, QuadratureBa
         }
         // blue checkered area (overwrites part of green n blue area)
         if( x > -0.15 + _centerGreen[0] && x < 0.15 + _centerGreen[0] && y > -0.35 + _centerGreen[1] && y < 0.35 + _centerGreen[1] ) {
-            _sigmaS[idx_cell] = 50.0;
+            _sigmaS[idx_cell] = 0.0;
             _sigmaT[idx_cell] = 100.0;
         }
         // black area (upper and lower boundary)
         if( y > 0.6 || y < -0.6 ) {
-            _sigmaS[idx_cell] = 100.0;
+            _sigmaS[idx_cell] = 50.0;
             _sigmaT[idx_cell] = 100.0;
         }
     }

--- a/src/solvers/snsolver_hpc.cpp
+++ b/src/solvers/snsolver_hpc.cpp
@@ -580,17 +580,17 @@ void SNSolverHPC::IterPostprocessing() {
 
             // Variation in absorption of center (part 1)
             // green area 1 (lower boundary)
-            bool green1 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < -0.15 + _settings->GetPosXCenterGreenHohlraum() &&
-                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 2 (upper boundary)
-            bool green2 = x > 0.15 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
-                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 3 (left boundary)
-            bool green3 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+            bool green1 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
                           y > -0.4 + _settings->GetPosYCenterGreenHohlraum() && y < -0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 4 (right boundary)
-            bool green4 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+            // green area 2 (upper boundary)
+            bool green2 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
                           y > 0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.4 + _settings->GetPosYCenterGreenHohlraum();
+            // green area 3 (left boundary)
+            bool green3 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < -0.15 + _settings->GetPosXCenterGreenHohlraum() &&
+                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
+            // green area 4 (right boundary)
+            bool green4 = x > 0.15 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
             if( green1 || green2 || green3 || green4 ) {
                 a_g += ( _sigmaT[idx_cell] - _sigmaS[idx_cell] ) * _scalarFlux[idx_cell] * _areas[idx_cell];
             }
@@ -701,17 +701,17 @@ void SNSolverHPC::IterPostprocessing() {
             double y = _cellMidPoints[Idx2D( idx_cell, 1, _nDim )];
 
             // green area 1 (lower boundary)
-            bool green1 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < -0.15 + _settings->GetPosXCenterGreenHohlraum() &&
-                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 2 (upper boundary)
-            bool green2 = x > 0.15 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
-                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 3 (left boundary)
-            bool green3 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+            bool green1 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
                           y > -0.4 + _settings->GetPosYCenterGreenHohlraum() && y < -0.35 + _settings->GetPosYCenterGreenHohlraum();
-            // green area 4 (right boundary)
-            bool green4 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+            // green area 2 (upper boundary)
+            bool green2 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
                           y > 0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.4 + _settings->GetPosYCenterGreenHohlraum();
+            // green area 3 (left boundary)
+            bool green3 = x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < -0.15 + _settings->GetPosXCenterGreenHohlraum() &&
+                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
+            // green area 4 (right boundary)
+            bool green4 = x > 0.15 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
+                          y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum();
             if( green1 || green2 || green3 || green4 ) {
                 _varAbsorptionHohlraumGreen += ( a_g - _scalarFlux[idx_cell] * ( _sigmaT[idx_cell] - _sigmaS[idx_cell] ) ) *
                                                ( a_g - _scalarFlux[idx_cell] * ( _sigmaT[idx_cell] - _sigmaS[idx_cell] ) ) * _areas[idx_cell];
@@ -724,7 +724,7 @@ void SNSolverHPC::IterPostprocessing() {
             temp_probingMoments[Idx2D( idx_probe, 1, 3 )] = 0.0;
             temp_probingMoments[Idx2D( idx_probe, 2, 3 )] = 0.0;
 
-            for( unsigned idx_sys = 0; idx_sys < _localNSys; idx_sys++ ) {    // TODO
+            for( unsigned idx_sys = 0; idx_sys < _localNSys; idx_sys++ ) {
                 temp_probingMoments[Idx2D( idx_probe, 0, 3 )] +=
                     _sol[Idx2D( _probingCellsHohlraum[idx_probe], idx_sys, _localNSys )] * _quadWeights[idx_sys];
                 temp_probingMoments[Idx2D( idx_probe, 1, 3 )] += _quadPts[Idx2D( idx_sys, 0, _nDim )] *

--- a/src/solvers/snsolver_hpc.cpp
+++ b/src/solvers/snsolver_hpc.cpp
@@ -565,7 +565,7 @@ void SNSolverHPC::IterPostprocessing() {
             double y = _cellMidPoints[Idx2D( idx_cell, 1, _nDim )];
 
             if( x > -0.2 + _settings->GetPosXCenterGreenHohlraum() && x < 0.2 + _settings->GetPosXCenterGreenHohlraum() &&
-                y > -0.35 + _settings->GetPosYCenterGreenHohlraum() && y < 0.35 + _settings->GetPosYCenterGreenHohlraum() ) {
+                y > -0.4 + _settings->GetPosYCenterGreenHohlraum() && y < 0.4 + _settings->GetPosYCenterGreenHohlraum() ) {
                 _curAbsorptionHohlraumCenter += _scalarFlux[idx_cell] * ( _sigmaT[idx_cell] - _sigmaS[idx_cell] ) * _areas[idx_cell];
             }
             if( ( x < _settings->GetPosRedLeftBorderHohlraum() && y > _settings->GetPosRedLeftBottomHohlraum() &&


### PR DESCRIPTION
## Proposed Changes
* Adds an CMAKE flage BUILD_MPI to support mpi builds and singularity. BUILD_MPI is per default false, to enable singularity deployment. MPI parallelizes the velocity space discretization
* MAJOR FIX: All Hohlraum test case setups correspond have now the parameters of this publication:

@article{CROCKATT2019455,
title = {Hybrid methods for radiation transport using diagonally implicit Runge–Kutta and space–time discontinuous Galerkin time integration},
journal = {Journal of Computational Physics},
volume = {376},
pages = {455-477},
year = {2019},
issn = {0021-9991},
doi = {https://doi.org/10.1016/j.jcp.2018.09.041},
url = {https://www.sciencedirect.com/science/article/pii/S0021999118306430},
author = {Michael M. Crockatt and Andrew J. Christlieb and C. Kristopher Garrett and Cory D. Hauck},
keywords = {Hybrid methods, Kinetic equations, Fully implicit methods, High-order accuracy},
abstract = {In this work, we describe extensions of a hybrid method for time-dependent linear, kinetic radiation transport problems to high-order time integration schemes of the diagonally-implicit Runge–Kutta (DIRK) and space–time discontinuous Galerkin (STDG) types. The hybrid methods are constructed by splitting the radiation flux into collided and uncollided components to which low- and high-resolution discrete ordinates approximations are applied. The efficiency of hybrid methods constructed using DIRK, STDG, integral deferred correction (IDC), and implicit Euler schemes is compared using a test problem in one-dimensional slab geometry containing material discontinuities. It is observed that (i) higher-order methods are more efficient than the implicit Euler method, often by an order of magnitude or more; (ii) third-order methods yield solutions of a given error in roughly half the time of the second-order method of the same type; and (iii) for a given order of accuracy it is found that the most efficient class of time integration scheme is STDG, followed by DIRK, with IDC the least efficient, for the test problem considered. Two test problems in two-dimensional xy-geometry are used to compare the computational efficiency of hybrid and standard discrete ordinates methods constructed with DIRK and STDG integrators. We observe that replacing a standard discrete ordinates method using an angular quadrature of order N with a hybrid discrete ordinates method using angular quadratures of order 2N and N/2 for the uncollided and collided fluxes, respectively, usually reduces overall solution time by a factor of 2 or more while simultaneously reducing the resulting solution error by a factor of 2 or more for the test problems considered.}
}




## Related Work
*Resolve any issues (bug fix or feature request), note any related PRs, or mention interactions with the work of others, if any.*



## PR Checklist
*Put an X by all that apply. You can fill this out after submitting the PR.*

- [ ] I am submitting my contribution to the develop branch.
- [ ] My contribution is commented and uses the code style of the project (see .clang-format).
- [ ] I have added a test case that demonstrates my contribution, if necessary.
- [ ] I have added unit tests to protect my modules, if neccessary.
- [ ] I have updated appropriate documentation (Tutorials, RTD Page) , if necessary.
